### PR TITLE
Added pageType toggle to post page and username links to dashboards

### DIFF
--- a/client/src/components/Post/index.jsx
+++ b/client/src/components/Post/index.jsx
@@ -5,7 +5,7 @@ export default function Post({ post }) {
   console.log(post)
   return (
     <a href={`/posts/${post._id}`} className="post" {...props}>
-      <h2>{post.user.username}</h2>
+      <a href={`/dashboard/${post.user._id}`}>{post.user.username}</a>
       <img src={post.imageURL ? post.imageURL : "https://placehold.co/800x600?text=Missing Image"} alt="post_img" />
       <h2>{post.caption ? post.caption : ''}</h2>
     </a>

--- a/client/src/components/comment.jsx
+++ b/client/src/components/comment.jsx
@@ -35,7 +35,7 @@ export default function Comment ({item, type}) {
         return(
             <>
                 <div>
-                    <p>{item.user.username}</p>
+                    <a href={`/dashboard/${item.user._id}`}>{item.user.username}</a>
                     <p>{item.createdAt}</p>
                     <p>{item.text}</p>
                 </div>

--- a/client/src/pages/postPage/postPage.jsx
+++ b/client/src/pages/postPage/postPage.jsx
@@ -46,9 +46,11 @@ export default function postPage () {
     if(pageType === 'post') {
         return(
             <>
+                <a id='backbutton' href='/'>Back</a>
+                <input type='checkbox' id='pageTypeToggle' checked='pageType' onClick={handlePageTypeChange}>pageType</input>
                 <div>
                     <section>
-                        <h2>{post.user.username}</h2>
+                        <a href={`/dashboard/${post.user._id}`}>{post.user.username}</a>
                         <h3>Other info?</h3>
                     </section>
                     <section>
@@ -56,7 +58,7 @@ export default function postPage () {
                         <div>
                             {post.caption !== null ? ( 
                                 <>
-                                    <h3>{post.caption.user.username}</h3>
+                                    <a href={`/dashboard/${post.caption.user._id}`}>{post.caption.user.username}</a>
                                     <h4>{post.caption.text}</h4>
                                 </>
                                 ):(
@@ -79,23 +81,33 @@ export default function postPage () {
     if(pageType === 'vote') {
         return(
             <>
-                <h2>{post.user.username}</h2>
-                <h3>Other info?</h3>
-                <img src={post.imageURL}/>
-                {post.caption !== null ?
-                    (
-                        <div>
-                            <h3>{post.caption.user.username}</h3>
-                            <h4>{post.caption.text}</h4>
-                        </div>
-                    ) : (
-                        <div>
-                            <p>Caption hasn't been chosen yet</p>
-                        </div>
-                    )
-                }
-
-                <h1>Leaderboard component here</h1>
+                <div>
+                    <a href='/' id='backButton'>Back</a>
+                    <input type='checkbox' id='pageTypeToggle' checked='pageType' onChange={handlePageTypeChange}>pageType</input>
+                    <section>
+                        <a href={`/dashboard/${post.user._id}`}>{post.user.username}</a>
+                        <h3>Other info?</h3>
+                    </section>
+                    <section>
+                    <img src={post.imageURL}/>
+                    {post.caption !== null ?
+                        (
+                            <div>
+                                <a href={`/dashboard/${post.caption.user._id}`}>{post.caption.user.username}</a>
+                                <h4>{post.caption.text}</h4>
+                            </div>
+                        ) : (
+                            <div>
+                                <p>Caption hasn't been chosen yet</p>
+                            </div>
+                        )
+                    }
+                    </section>
+                    <section>
+                        <h1>leaderboard component here</h1>
+                    </section>
+                
+                </div>
             </>
         )
     }


### PR DESCRIPTION
- Each username on a post or comment now acts as a link to that users dashboard page. 
- The individual post page now has a toggle and back button near the top. The toggle changes the page type and the back button is a link to the home page. Neither have styling yet. 